### PR TITLE
Upgrade micropub-helper to 1.3.3, fixes support for sites with <base> tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "microformat-shiv": "^2.0.3",
-    "micropub-helper": "^1.3.2",
+    "micropub-helper": "^1.3.3",
     "parse-uri": "^1.0.0",
     "preact": "^7.2.0"
   }


### PR DESCRIPTION
I [fixed micropub-helper itself](https://github.com/grantcodes/micropub/pull/6) but Omnibear's still not working for my site since it hasn't got the update yet. So, yeah! :wink: 

I tried to update package-lock.json as well, but it made a colossal amount of unrelated changes - I think because I'm on MacOS and can install `fsevents` - and I noticed that package-lock.json *wasn't* updated in 3ca18c87ad64cfff1a07649c3ae33af3eba49ea3 so I figured it'd be fine to do the same thing.