### PR TITLE
Increase version of micropub-helper to 1.3.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "microformat-shiv": "^2.0.3",
-    "micropub-helper": "^1.3.4",
+    "micropub-helper": "^1.3.10",
     "parse-uri": "^1.0.0",
     "preact": "^7.2.0"
   }


### PR DESCRIPTION
- This fixes encoding of array arguments for categories and mp-syndicate-to. https://github.com/grantcodes/micropub/issues/8
- It also contains Link rel parsing it seems. https://github.com/grantcodes/micropub/issues/7