### PR TITLE
Replace syndication targets with the response from the endpoint

### DIFF
--- a/src/background/authentication.js
+++ b/src/background/authentication.js
@@ -56,9 +56,11 @@ export function fetchToken(code) {
 
 export function fetchSyndicationTargets() {
   return micropub.query('syndicate-to').then(response => {
-    localStorage.setItem(
-      'syndicateTo',
-      JSON.stringify(response['syndicate-to'])
-    );
+    const syndicateTo = response['syndicate-to'];
+    if (Array.isArray(syndicateTo)) {
+      localStorage.setItem('syndicateTo', JSON.stringify(syndicateTo));
+    } else {
+      localStorage.setItem('syndicateTo', JSON.stringify([]));
+    }
   });
 }

--- a/src/background/authentication.js
+++ b/src/background/authentication.js
@@ -56,11 +56,9 @@ export function fetchToken(code) {
 
 export function fetchSyndicationTargets() {
   return micropub.query('syndicate-to').then(response => {
-    const syndicateTo = response['syndicate-to'];
-    if (response.ok && Array.isArray(syndicateTo)) {
-      localStorage.setItem('syndicateTo', JSON.stringify(syndicateTo));
-    } else {
-      localStorage.setItem('syndicateTo', JSON.stringify([]));
-    }
+    localStorage.setItem(
+      'syndicateTo',
+      JSON.stringify(response['syndicate-to'])
+    );
   });
 }


### PR DESCRIPTION
I put back the original fetchSyndicationTargets function. The response doesn't contain "ok", as the micropub helper returns the json object.