### PR TITLE
feat: add context menu option to bookmark links (#122)

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -165,7 +165,18 @@ export default function main() {
 		});
 	}
 
-	function onContextMenuClick() {
+	async function onContextMenuClick(info) {
+		if (info.menuItemId === "Bookmark") {
+			const bookmarkEntry = {
+				type: ["h-entry"],
+				properties: {
+					"bookmark-of": [info.linkUrl],
+				},
+			};
+			await selectEntry(bookmarkEntry);
+		} else {
+			await clearEntry();
+		}
 		browser.action.openPopup();
 	}
 
@@ -176,6 +187,13 @@ export default function main() {
 			title: "Reply to entry",
 			contexts: ["page", "image", "link", "audio", "video", "selection"],
 			// Don't want "Reply" menu to appear on extension pages or within the omnibear popup
+			documentUrlPatterns: ["http://*/*", "https://*/*"],
+		});
+
+		browser.contextMenus.create({
+			id: "Bookmark",
+			title: "Bookmark link",
+			contexts: ["link"],
 			documentUrlPatterns: ["http://*/*", "https://*/*"],
 		});
 		browser.action.setBadgeBackgroundColor({ color: "#444" });


### PR DESCRIPTION
Resolves #122

### Summary
This PR adds a "Bookmark link" option to the context menu when right-clicking standard links. This allows users to bookmark URLs that do not contain Microformats data, improving the experience for saving random links.

### Changes
- Added a new context menu item `"Bookmark link"` that appears specifically for `link` contexts.
- Updated `onContextMenuClick` in `src/background/index.js` to handle the new menu item ID.
- The action captures the `linkUrl` and saves it as a `bookmark-of` entry in storage, which the popup then uses to pre-fill the bookmark form.

### Testing
- [x] Verified that the "Bookmark link" option appears in the context menu when right-clicking a URL.
- [x] Verified that clicking the option opens the Omnibear popup.
- [x] Verified that the popup correctly pre-fills the "Bookmark" field with the clicked URL.
- [x] ensured `npm run check` and `npm test` pass.
